### PR TITLE
add override_hostname to gmond for >3.2.0 version ganglia

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "darrin@heavywater.ca"
 license          "Apache 2.0"
 description      "Installs/Configures ganglia"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.1.1"
+version          "0.1.2"
 
 %w{ debian ubuntu redhat centos fedora }.each do |os|
   supports os

--- a/templates/default/gmond.conf.erb
+++ b/templates/default/gmond.conf.erb
@@ -12,8 +12,11 @@ globals {
   cleanup_threshold = 300 /*secs */ 
   gexec = no             
   send_metadata_interval = 0     
-} 
-
+  <% if @override -%>
+     override_hostname = <%= node['fqdn'] %>
+  <% end -%>
+}
+ 
 /* If a cluster attribute is specified, then all gmond hosts are wrapped inside 
  * of a <CLUSTER> tag.  If you do not specify a cluster tag, then all <HOSTS> will 
  * NOT be wrapped inside of a <CLUSTER> tag. */ 


### PR DESCRIPTION
it's update is very helpfull. Debian 7.0 have a 3.3.8 version of ganglia-monitor.
