### PR TITLE
Fixing the URI for the download so it respects the version attribute.

### DIFF
--- a/attributes/ganglia.rb
+++ b/attributes/ganglia.rb
@@ -1,5 +1,5 @@
 default[:ganglia][:version] = "3.1.7"
-default[:ganglia][:uri] = "http://sourceforge.net/projects/ganglia/files/ganglia%20monitoring%20core/3.1.7/ganglia-3.1.7.tar.gz/download"
+default[:ganglia][:uri] = "http://sourceforge.net/projects/ganglia/files/ganglia%20monitoring%20core/#{node[:ganglia][:version]}/ganglia-#{node[:ganglia][:version]}.tar.gz/download"
 default[:ganglia][:checksum] = "bb1a4953"
 default[:ganglia][:cluster_name] = "default"
 default[:ganglia][:unicast] = false


### PR DESCRIPTION
Fixing the URI for the download so it respects the version attribute. As originally written, it'll download 3.1.7 regardless of the version specified (assuming that you ignore the checksum).
