### PR TITLE
Allow explicitly specifying server hostname for unicast configuration

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "darrin@heavywater.ca"
 license          "Apache 2.0"
 description      "Installs/Configures ganglia"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.1.1"
+version          "0.1.2"
 
 %w{ debian ubuntu redhat centos fedora }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,8 +37,11 @@ directory "/etc/ganglia"
 
 case node[:ganglia][:unicast]
 when true
-  host = search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node.ipaddress}
-  if host.empty? 
+  host = node['ganglia']['server_host']  # the user can specify the server FQDN
+  unless host
+    search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node.ipaddress}
+  end
+  if host.empty?
      host = "127.0.0.1"
   end
   template "/etc/ganglia/gmond.conf" do


### PR DESCRIPTION
Sometimes it is more convenient to provide a Ganglia server hostname instead of relying on Chef search and Ohai to find it.
