### PR TITLE
collectors should be an array if no collectors are found

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,7 +60,7 @@ when true
     gmond_collectors = search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node.ipaddress}
   end rescue NoMethodError
   if gmond_collectors.empty? 
-     gmond_collectors = "127.0.0.1"
+     gmond_collectors = ["127.0.0.1"]
   end
 
   template "/etc/ganglia/gmond.conf" do


### PR DESCRIPTION
When failing to find collector hosts via chef search or the existing attributes, default to localhost. The value is supposed to be an array, not a string.
