### PR TITLE
Remove library path hard-coding

### DIFF
--- a/templates/default/gmond.conf.erb
+++ b/templates/default/gmond.conf.erb
@@ -68,31 +68,31 @@ modules {
   } 
   module { 
     name = "cpu_module" 
-    path = "/usr/lib/ganglia/modcpu.so" 
+    path = "modcpu.so" 
   } 
   module { 
     name = "disk_module" 
-    path = "/usr/lib/ganglia/moddisk.so" 
+    path = "moddisk.so" 
   } 
   module { 
     name = "load_module" 
-    path = "/usr/lib/ganglia/modload.so" 
+    path = "modload.so" 
   } 
   module { 
     name = "mem_module" 
-    path = "/usr/lib/ganglia/modmem.so" 
+    path = "modmem.so" 
   } 
   module { 
     name = "net_module" 
-    path = "/usr/lib/ganglia/modnet.so" 
+    path = "modnet.so" 
   } 
   module { 
     name = "proc_module" 
-    path = "/usr/lib/ganglia/modproc.so" 
+    path = "modproc.so" 
   } 
   module { 
     name = "sys_module" 
-    path = "/usr/lib/ganglia/modsys.so" 
+    path = "modsys.so" 
   } 
 } 
 

--- a/templates/default/gmond_unicast.conf.erb
+++ b/templates/default/gmond_unicast.conf.erb
@@ -58,31 +58,31 @@ modules {
   } 
   module { 
     name = "cpu_module" 
-    path = "/usr/lib/ganglia/modcpu.so" 
+    path = "modcpu.so" 
   } 
   module { 
     name = "disk_module" 
-    path = "/usr/lib/ganglia/moddisk.so" 
+    path = "moddisk.so" 
   } 
   module { 
     name = "load_module" 
-    path = "/usr/lib/ganglia/modload.so" 
+    path = "modload.so" 
   } 
   module { 
     name = "mem_module" 
-    path = "/usr/lib/ganglia/modmem.so" 
+    path = "modmem.so" 
   } 
   module { 
     name = "net_module" 
-    path = "/usr/lib/ganglia/modnet.so" 
+    path = "modnet.so" 
   } 
   module { 
     name = "proc_module" 
-    path = "/usr/lib/ganglia/modproc.so" 
+    path = "modproc.so" 
   } 
   module { 
     name = "sys_module" 
-    path = "/usr/lib/ganglia/modsys.so" 
+    path = "modsys.so" 
   } 
 } 
 


### PR DESCRIPTION
Some systems use /usr/lib64 instead of /usr/lib. This removes the hard
coding so ganglia can find the libraries properly.

Signed-off-by: Joshua Kugler joshua@azariah.com
