### PR TITLE
add options for rrdcached timeout and delay values

### DIFF
--- a/attributes/ganglia.rb
+++ b/attributes/ganglia.rb
@@ -39,6 +39,10 @@ default[:ganglia][:rrdcached][:main_socket] = "/tmp/rrdcached.sock"
 default[:ganglia][:rrdcached][:limited_socket] = "/tmp/rrdacached_limited.sock"
 # where do the ganglia rrds live
 default[:ganglia][:rrdcached][:ganglia_rrds] = node[:ganglia][:rrd_rootdir]
+# how often to write rrds in secs
+default[:ganglia][:rrdcached][:timeout] = 300 # rrdcached's default
+# random splay for individual rrd writes
+default[:ganglia][:rrdcached][:delay] = 240 # previous hard-coded value
 
 # attributes for web configuration
 # whether to use authentication: options 'disabled', 'readonly', and 'enabled'

--- a/recipes/gmetad.rb
+++ b/recipes/gmetad.rb
@@ -34,7 +34,9 @@ if node[:ganglia][:enable_rrdcached] == true
       :user => node[:ganglia][:rrdcached][:user],
       :main_socket => node[:ganglia][:rrdcached][:main_socket],
       :limited_socket => node[:ganglia][:rrdcached][:limited_socket],
-      :ganglia_rrds => node[:ganglia][:rrdcached][:ganglia_rrds]
+      :ganglia_rrds => node[:ganglia][:rrdcached][:ganglia_rrds],
+      :timeout => node[:ganglia][:rrdcached][:timeout],
+      :delay => node[:ganglia][:rrdcached][:delay],
       }
     )
   end

--- a/templates/default/sv-rrdcached-run.erb
+++ b/templates/default/sv-rrdcached-run.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -u <%= @options[:user] %> /usr/bin/rrdcached -w 300 -z 240 -F -g -p /tmp/rrdcached.pid \
+exec chpst -u <%= @options[:user] %> /usr/bin/rrdcached -w <%= @options[:timeout] %> -z <%= @options[:delay] %> -F -g -p /tmp/rrdcached.pid \
     -m 664 -l unix:<%= @options[:main_socket] %> \
     -m 777 -P FLUSH,STATS,HELP -l unix:<%= @options[:limited_socket] %> \
     -b <%= @options[:ganglia_rrds] %> -B


### PR DESCRIPTION
This adds options to the template for rrdcached's run script to control timeout (how often to write rrds) and delay (random splay for individual rrds) as well as default attributes with values equal to the currently hardcoded values.

The existing behavior writes out rrds within 5min of receiving them, while I have configured my systems to write out every 30s for real-time-y looking graphs.  Different patterns of collection and IO bandwidth will benefit from wildly different values for these config options.
