### PR TITLE
gmetad starts automatically with package install

### DIFF
--- a/recipes/gmetad.rb
+++ b/recipes/gmetad.rb
@@ -1,6 +1,14 @@
+service "gmetad" do
+  supports :restart => true, :start => true, :stop => true, :reload => true
+  action :nothing
+end
+
 case node['platform']
 when "ubuntu", "debian"
-  package "gmetad"
+  package "gmetad" do
+      action :install
+      notifies :stop, "service[gmetad]", :immediately
+  end
 when "redhat", "centos", "fedora"
   include_recipe "ganglia::source"
   execute "copy gmetad init script" do
@@ -97,8 +105,8 @@ template "/etc/init.d/gmetad" do
   variables( :gmetad_name => "gmetad" )
   notifies :restart, "service[gmetad]"
 end
+
 service "gmetad" do
-  supports :restart => true
   action [ :enable, :start ]
 end
 


### PR DESCRIPTION
when you install the package (at least on ubuntu 12.04), it automatically starts the gmetad process, the init script dropped by the recipe makes it impossible to control that original gmetad process from the new init script.

So I just make the package stop the process (if any gets installed) immediately after the install.

alternatives are:
1. use /etc/defaults to control the package installed version starting
2. find the pid file and make the new init script also use it
