### PR TITLE
add all_trusted attr for gmetad.

### DIFF
--- a/attributes/ganglia.rb
+++ b/attributes/ganglia.rb
@@ -9,6 +9,7 @@ default['ganglia']['rrd_rootdir'] = "/var/lib/ganglia/rrds"
 default['ganglia']['gmetad']['xml_port'] = 8651
 default['ganglia']['gmetad']['interactive_port'] = 8652
 default['ganglia']['gmetad']['trusted_hosts'] = nil
+default['ganglia']['gmetad']['all_trusted'] = nil
 default['ganglia']['spoof_hostname'] = false
 
 default['ganglia']['mod_path'] = ''

--- a/templates/default/gmetad.conf.erb
+++ b/templates/default/gmetad.conf.erb
@@ -92,6 +92,9 @@ trusted_hosts <%= @trusted_hosts.map {|host| host.to_s}.join(' ') %>
 # data, then set this value to "on"
 # default: off
 # all_trusted on
+<% unless @all_trusted.nil? %>
+all_trusted <%= @all_trusted %>
+<% end %>
 #
 #-------------------------------------------------------------------------------
 # If you don't want gmetad to setuid then set this to off


### PR DESCRIPTION
The cookbook already supports an attribute for gmetad which sets trusted hosts, but in scenarios where the entire network is trusted, the 'all trusted' attribute is handy when set to 'yes'.

This patch enables configuration of that attribute.
