### PR TITLE
fix the options symbols bug in rrdcached template

### DIFF
--- a/templates/default/sv-rrdcached-run.erb
+++ b/templates/default/sv-rrdcached-run.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -u <%= @options['user'] %> /usr/bin/rrdcached -w <%= @options['timeout'] %> -z <%= @options['delay'] %> -F -g -p /tmp/rrdcached.pid \
-    -m 664 -l unix:<%= @options['main_socket'] %> \
-    -m 777 -P FLUSH,STATS,HELP -l unix:<%= @options['limited_socket'] %> \
-    -b <%= @options['ganglia_rrds'] %> -B
+exec chpst -u <%= @options[:user] %> /usr/bin/rrdcached -w <%= @options[:timeout] %> -z <%= @options[:delay] %> -F -g -p /tmp/rrdcached.pid \
+    -m 664 -l unix:<%= @options[:main_socket] %> \
+    -m 777 -P FLUSH,STATS,HELP -l unix:<%= @options[:limited_socket] %> \
+    -b <%= @options[:ganglia_rrds] %> -B


### PR DESCRIPTION
`@options['user']` will return `nil` in the rrdcached template, so it should be `@options[:user]`. So do other options.
