### PR TITLE
fix the web interactive_port bug

### DIFF
--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -52,15 +52,15 @@ if node['ganglia']['web']['auth_system'] == "enabled"
   end
 end
 
-xml_port = if node['ganglia']['enable_two_gmetads'] then
-                node['ganglia']['two_gmetads']['xml_port']
+interactive_port = if node['ganglia']['enable_two_gmetads'] then
+                node['ganglia']['two_gmetads']['interactive_port']
            else
-                node['ganglia']['gmetad']['xml_port']
+                node['ganglia']['gmetad']['interactive_port']
            end
 template "/etc/ganglia-webfrontend/conf.php" do
   source "webconf.php.erb"
   mode "0644"
-  variables( :xml_port => xml_port, :users => users.nil? ? '' : users )
+  variables( :interactive_port => interactive_port, :users => users.nil? ? '' : users )
 end
 
 service "apache2" do

--- a/templates/default/webconf.php.erb
+++ b/templates/default/webconf.php.erb
@@ -8,7 +8,7 @@ $conf['auth_system'] = '<%= node['ganglia']['web']['auth_system'] %>';
 <% if node['ganglia']['enable_rrdcached'] %>
 $conf['rrdcached_socket'] = "<%= node['ganglia']['rrdcached']['limited_socket'] %>";
 <% end %>
-$conf['ganglia_port'] = <%= @xml_port %>;
+$conf['ganglia_port'] = <%= @interactive_port %>;
 <% if node['ganglia']['web']['auth_system'] == 'enabled' %>
 $acl = GangliaAcl::getInstance();
 <% @users.each do |user| %>


### PR DESCRIPTION
It seems ganglia_port need to be set to interactive_port(8652), so that ganglia-web can work normally.
