### PR TITLE
set rrd root dir in web front end config.

### DIFF
--- a/templates/default/webconf.php.erb
+++ b/templates/default/webconf.php.erb
@@ -5,6 +5,9 @@
 #             An administrator must configure an authentication scheme and ACL rules.
 # 'disabled': Guest users may perform any actions, including edits.  No authentication is required.
 $conf['auth_system'] = '<%= node['ganglia']['web']['auth_system'] %>';
+<% if node['ganglia']['rrd_rootdir'] %>
+$conf['rrds'] = "<%= node['ganglia']['rrd_rootdir'] %>";
+<% end %>
 <% if node['ganglia']['enable_rrdcached'] %>
 $conf['rrdcached_socket'] = "<%= node['ganglia']['rrdcached']['limited_socket'] %>";
 <% end %>


### PR DESCRIPTION
When using an alternate rrd_rootdir, the web front end breaks if it is not configured properly.

This patch fixes that.
