### PR TITLE
Issue#50

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,7 +83,7 @@ end
 
 service "ganglia-monitor" do
   pattern "gmond"
-  provider Chef::Provider::Service::Upstart if (node.platform?('ubuntu') && node.platform_version.include?('14'))
+  provider Chef::Provider::Service::Upstart if (platform?('ubuntu') && node.platform_version.include?('14'))
   supports :restart => true
   action [ :enable, :start ]
 end


### PR DESCRIPTION
This pull request get allow configure ganglia-monitor on ubuntu 14.04. This is temporary solution until Chef Opscode change service provider for ubuntu > 13.10 to upstart or ubuntu package ganglia-monitor fix upstart config (or init.d script).
