### PR TITLE
add features to get remote ganglia python modules

### DIFF
--- a/providers/python.rb
+++ b/providers/python.rb
@@ -3,13 +3,22 @@
 action :enable do
 
   #python module
-  template "/usr/lib/ganglia/python_modules/#{new_resource.module_name}.py" do
-    source "ganglia/#{new_resource.module_name}.py.erb"
-    owner "root"
-    group "root"
-    mode "644"
-    variables :options => new_resource.options
-    notifies :restart, "service[ganglia-monitor]"
+  if new_resource.github
+    githuburl = "https://raw.githubusercontent.com/ganglia/gmond_python_modules/master/#{new_resource.module_name}/python_modules/#{new_resource.module_name}.py"
+    remote_file "/usr/lib/ganglia/python_modules/#{new_resource.module_name}.py" do
+      source githuburl
+      mode 00644
+      action :create_if_missing
+    end
+  else
+    template "/usr/lib/ganglia/python_modules/#{new_resource.module_name}.py" do
+      source "ganglia/#{new_resource.module_name}.py.erb"
+      owner "root"
+      group "root"
+      mode "644"
+      variables :options => new_resource.options
+      notifies :restart, "service[ganglia-monitor]"
+    end
   end
 
   #configuration

--- a/resources/python.rb
+++ b/resources/python.rb
@@ -2,4 +2,5 @@ actions :enable, :disable
 default_action :enable
 
 attribute :module_name, :kind_of => String, :name_attribute => true
-attribute :options, :kind_of => Hash, :default => {}
+attribute :options,     :kind_of => Hash, :default => {}
+attribute :github,      :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
This request to get ability to get ganglia python modules via LWRP resource from github repository directly. 
It's to get allow to not create .erb template for modules if it's not needed. 
