### PR TITLE
removing name from gmond collector startscript stop command

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email "ganglia-developers@lists.sourceforge.net"
 license          "Apache 2.0"
 description      "Installs/Configures ganglia"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.3"
+version          "0.2.4"
 
 %w{ debian ubuntu redhat centos fedora }.each do |os|
   supports os

--- a/templates/default/gmond_collector-startscript.erb
+++ b/templates/default/gmond_collector-startscript.erb
@@ -26,7 +26,7 @@ case "$1" in
   stop)
   echo -n "Stopping $DESC: "
   start-stop-daemon --stop  --quiet --oknodo \
-    --pidfile /var/run/${NAME}.pid --name $NAME 2>&1 > /dev/null
+    --pidfile /var/run/${NAME}.pid 2>&1 > /dev/null
   echo "$NAME."
   ;;
   reload)


### PR DESCRIPTION
In ubuntu 14.04 the stop command was not working for a collector.  When the name is removed and just the pid file is used, everything works fine.