### PR TITLE
Bugfix on centos

### DIFF
--- a/recipes/gmetad.rb
+++ b/recipes/gmetad.rb
@@ -91,12 +91,15 @@ when false
 end
 
 # drop in our own gmetad init script to enable rrdcached if appropriate
-template "/etc/init.d/gmetad" do
-  source "gmetad-startscript.erb"
-  mode "0755"
-  variables( :gmetad_name => "gmetad" )
-  notifies :restart, "service[gmetad]"
+if node['ganglia']['enable_rrdcached'] == true
+  template "/etc/init.d/gmetad" do
+    source "gmetad-startscript.erb"
+     mode "0755"
+     variables( :gmetad_name => "gmetad" )
+     notifies :restart, "service[gmetad]"
+  end
 end
+
 service "gmetad" do
   supports :restart => true
   action [ :enable, :start ]

--- a/templates/default/gmetad.conf.erb
+++ b/templates/default/gmetad.conf.erb
@@ -127,7 +127,9 @@ interactive_port <%= @interactive_port %>
 # default: "/var/lib/ganglia/rrds"
 rrd_rootdir "<%= @rrd_rootdir %>"
 #
+<% if node[:ganglia][:option_write_rrds_supported]==true -%>
 #-------------------------------------------------------------------------------
 # Controls whether gmetad will write rrds to disk
 # default: on
 write_rrds <%= @write_rrds %>
+<% end %>


### PR DESCRIPTION
Drop in template /etc/init.d/gmetad only if needed (if enable_rrdcached is true)
Added option to disable the gmetad config option write_rrds (could be unsupported)

Signed-off-by: Martin Wilhelm martin@system4.org
