### PR TITLE
Refactor gmetad config for clusters

### DIFF
--- a/spec/unit/recipes/gmetad_spec.rb
+++ b/spec/unit/recipes/gmetad_spec.rb
@@ -17,7 +17,7 @@ describe 'ganglia::gmetad' do
       end
       hosts << n
     end
-    stub_search(:node, '*:*').and_return(hosts)
+    stub_search(:node, 'ganglia_host_cluster_default:1').and_return(hosts)
   end
 
   it 'installs the gmetad package' do
@@ -45,9 +45,9 @@ describe 'ganglia::gmetad' do
     it 'creates gmetad.conf' do
       expect(chef_run).to create_template("/etc/ganglia/gmetad.conf").with(
         variables: {
-          :clusters => {"default" => 18649},
-          :hosts => ["host1", "host2"],
+          :clusters => {"default" => ["host1:18649", "host2:18649"]},
           :grid_name => "default",
+          :rrd_rootdir=>"/var/lib/ganglia/rrds",
           :params => {
             "xml_port"         => 8651,
             "interactive_port" => 8652,
@@ -81,8 +81,7 @@ describe 'ganglia::gmetad' do
     it 'creates gmetad.conf template' do
       expect(chef_run).to create_template('/etc/ganglia/gmetad.conf').with(
         :variables => {
-          :clusters => { 'default' => 18649 },
-          :hosts => ['host1', 'host2'],
+          :clusters => { "default" => ["host1:18649", "host2:18649"] },
           :params => {
             "xml_port"         => 8651,
             "interactive_port" => 8652,
@@ -116,8 +115,7 @@ describe 'ganglia::gmetad' do
     it 'creates gmetad.conf template' do
       expect(chef_run).to create_template('/etc/ganglia/gmetad.conf').with(
         :variables => {
-          :clusters => { 'default' => 18649 },
-          :hosts => ['127.0.0.1'],
+          :clusters=> { "default" => ["127.0.0.1:18649"] },
           :params => {
             "xml_port"         => 8651,
             "interactive_port" => 8652,
@@ -129,8 +127,7 @@ describe 'ganglia::gmetad' do
     it 'creates gmetad-norrds.conf template' do
       expect(chef_run).to create_template('/etc/ganglia/gmetad-norrds.conf').with(
         :variables => {
-          :clusters => { 'default' => 18649 },
-          :hosts => ['127.0.0.1'],
+          :clusters=> { "default" => ["127.0.0.1:18649"] },
           :params => {
             :xml_port         => 8661,
             :interactive_port => 8662,

--- a/templates/default/gmetad.conf.erb
+++ b/templates/default/gmetad.conf.erb
@@ -1,13 +1,9 @@
 # See gmetad-example.conf for detailed configuration file
 
-<%# the shuffle in @hosts.map balances load across the gmond collectors. %>
+<%# the shuffle on host balances load on gmonds %>
 <% require "digest/md5" %>
-<% @clusters.each do |cluster,port| %>
-data_source "<%= cluster %>" <%= @hosts.map do |host|
-    "#{host}:#{port}"
-  end.sort do |x,y|
-    Digest::MD5.hexdigest(node['hostname'] + x) <=> Digest::MD5.hexdigest(node['hostname'] + y)
-  end.join(' ') %>
+<% @clusters.each do |cluster,hosts| %>
+  data_source "<%= cluster %>" <%= hosts.sort_by { |x| Digest::MD5.hexdigest(node['hostname'] + x) }.join(' ') %>
 <% end %>
 
 <% @params.reject {|k,v| v.nil? }.each do |key,value|


### PR DESCRIPTION
Unicast case was previously broken: it takes all hosts to add them in
every cluster. Then it relies on the fact that gmetad will ignore hosts
that return bad output (or with closed port).

This changes lists each host only in the cluster it belongs to.

ps: my PR branch depends on all my previous merge requests but I could rebase it if you want