### PR TITLE
Install version 3.3.8 on ubuntu 12.04

### DIFF
--- a/attributes/ganglia.rb
+++ b/attributes/ganglia.rb
@@ -1,4 +1,8 @@
 default['ganglia']['version'] = "3.1.7"
+default['ganglia']['ubuntu_version'] = '3.3.8-1+nmu1_amd64'
+default['ganglia']['download_url'] = 'http://ftp.us.debian.org/debian/pool/main/g/ganglia'
+default['ganglia']['default_install'] = ['libganglia1', 'libganglia1-dev', 'ganglia-monitor']
+default['ganglia']['gmetad_install'] = 'gmetad'
 #default['ganglia']['uri'] = "http://sourceforge.net/projects/ganglia/files/ganglia%20monitoring%20core/#{node['ganglia']['version']}/ganglia-#{node['ganglia']['version']}.tar.gz/download"
 default['ganglia']['uri'] = "http://downloads.sourceforge.net/project/ganglia/ganglia%20monitoring%20core/#{node['ganglia']['version']}/ganglia-#{node['ganglia']['version']}.tar.gz"
 default['ganglia']['checksum'] = "bb1a4953"
@@ -33,16 +37,16 @@ default['ganglia']['gmond']['cluster'] = {
   url:     'unspecified',
 }
 default['ganglia']['gmond']['host'] = {
-  location: 'unspecified'
+  location: '127.0.0.1'
 }
 default['ganglia']['gmond']['tcp_accept_channel'] = { port: 8649 }
 default['ganglia']['gmond_default']['multicast_udp_send_channel'] = {
-  mcast_join: '239.2.11.71',
+ # mcast_join: '239.2.11.71',
   ttl:        1,
 }
 default['ganglia']['gmond_default']['multicast_udp_recv_channel'] = {
-  mcast_join: '239.2.11.71',
-  bind:       '239.2.11.71',
+ # mcast_join: '239.2.11.71',
+ # bind:       '239.2.11.71',
 }
 default['ganglia']['gmond_default']['unicast_udp_send_channel'] = {
   ttl:        1,
@@ -53,12 +57,12 @@ default['ganglia']['gmetad']['interactive_port'] = 8652
 default['ganglia']['gmetad']['trusted_hosts'] = nil
 default['ganglia']['gmetad']['all_trusted'] = nil
 default['ganglia']['gmetad']['write_rrds'] = nil # ganglia default is on
-default['ganglia']['gmetad']['carbon_server'] = nil
-default['ganglia']['gmetad']['carbon_port'] = nil
-default['ganglia']['gmetad']['graphite_prefix'] = nil
+default['ganglia']['gmetad']['carbon_server'] = '127.0.0.1'
+default['ganglia']['gmetad']['carbon_port'] = 2003
+default['ganglia']['gmetad']['graphite_prefix'] = 'test_graphite'
 default['ganglia']['spoof_hostname'] = false
 
-default['ganglia']['mod_path'] = ''
+default['ganglia']['mod_path'] = '/usr/lib/ganglia/'
 
 # Uncomment this to override the search for server_role and just specify the host instead
 # default['ganglia']['server_host'] = 'ganglia.example.com'
@@ -69,7 +73,7 @@ default['ganglia']['mod_path'] = ''
 # * don't use port 8649
 # * don't put spaces in cluster names
 default['ganglia']['clusterport'] = {
-                                    "default"       => 18649
+                                    "default"       => 8649
                                   }
 # this is set on the host to determine which cluster it should join
 # it's a hash with one key per cluster; it should join all clusters

--- a/attributes/ganglia.rb
+++ b/attributes/ganglia.rb
@@ -37,16 +37,16 @@ default['ganglia']['gmond']['cluster'] = {
   url:     'unspecified',
 }
 default['ganglia']['gmond']['host'] = {
-  location: '127.0.0.1'
+  location: 'unspecified'
 }
 default['ganglia']['gmond']['tcp_accept_channel'] = { port: 8649 }
 default['ganglia']['gmond_default']['multicast_udp_send_channel'] = {
- # mcast_join: '239.2.11.71',
+  mcast_join: '239.2.11.71',
   ttl:        1,
 }
 default['ganglia']['gmond_default']['multicast_udp_recv_channel'] = {
- # mcast_join: '239.2.11.71',
- # bind:       '239.2.11.71',
+  mcast_join: '239.2.11.71',
+  bind:       '239.2.11.71',
 }
 default['ganglia']['gmond_default']['unicast_udp_send_channel'] = {
   ttl:        1,
@@ -57,9 +57,9 @@ default['ganglia']['gmetad']['interactive_port'] = 8652
 default['ganglia']['gmetad']['trusted_hosts'] = nil
 default['ganglia']['gmetad']['all_trusted'] = nil
 default['ganglia']['gmetad']['write_rrds'] = nil # ganglia default is on
-default['ganglia']['gmetad']['carbon_server'] = '127.0.0.1'
-default['ganglia']['gmetad']['carbon_port'] = 2003
-default['ganglia']['gmetad']['graphite_prefix'] = 'test_graphite'
+default['ganglia']['gmetad']['carbon_server'] = nil
+default['ganglia']['gmetad']['carbon_port'] = nil
+default['ganglia']['gmetad']['graphite_prefix'] = nil
 default['ganglia']['spoof_hostname'] = false
 
 default['ganglia']['mod_path'] = '/usr/lib/ganglia/'
@@ -73,7 +73,7 @@ default['ganglia']['mod_path'] = '/usr/lib/ganglia/'
 # * don't use port 8649
 # * don't put spaces in cluster names
 default['ganglia']['clusterport'] = {
-                                    "default"       => 8649
+                                    "default"       => 18649
                                   }
 # this is set on the host to determine which cluster it should join
 # it's a hash with one key per cluster; it should join all clusters

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,8 +18,22 @@
 #
 
 case node['platform']
-when "ubuntu", "debian"
+when "debian"
   package "ganglia-monitor"
+
+when "ubuntu"
+  # Install required packages if it has not been installed 
+  %w{libapr1 libconfuse0}.each do |package_name|
+    package "#{package_name}"
+  end
+  # Download and install libganglia1, libganglia1-dev, ganglia-monitor
+  node['ganglia']['default_install'].each do |packet|
+    remote_file "/usr/src/#{packet}_#{node['ganglia']['ubuntu_version']}.deb" do
+      source "#{node['ganglia']['download_url']}/#{packet}_#{node['ganglia']['ubuntu_version']}.deb"
+    end 
+    dpkg_package "/usr/src/#{packet}_#{node['ganglia']['ubuntu_version']}.deb"
+  end
+
 when "redhat", "centos", "fedora"
   user "ganglia"
   case node['ganglia']['install_method']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,18 +22,22 @@ when "debian"
   package "ganglia-monitor"
 
 when "ubuntu"
-  # Install required packages if it has not been installed 
-  %w{libapr1 libconfuse0}.each do |package_name|
-    package "#{package_name}"
+  case node['platform_version']
+  when '12.04'
+    # Install required packages if it has not been installed     
+    %w{libapr1 libconfuse0}.each do |package_name|
+      package "#{package_name}"
+    end
+    # Download and install libganglia1, libganglia1-dev, ganglia-monitor
+    node['ganglia']['default_install'].each do |packet|
+      remote_file "/usr/src/#{packet}_#{node['ganglia']['ubuntu_version']}.deb" do
+        source "#{node['ganglia']['download_url']}/#{packet}_#{node['ganglia']['ubuntu_version']}.deb"
+      end 
+      dpkg_package "/usr/src/#{packet}_#{node['ganglia']['ubuntu_version']}.deb"
+    end
+  else 
+    package 'ganglia-monitor'
   end
-  # Download and install libganglia1, libganglia1-dev, ganglia-monitor
-  node['ganglia']['default_install'].each do |packet|
-    remote_file "/usr/src/#{packet}_#{node['ganglia']['ubuntu_version']}.deb" do
-      source "#{node['ganglia']['download_url']}/#{packet}_#{node['ganglia']['ubuntu_version']}.deb"
-    end 
-    dpkg_package "/usr/src/#{packet}_#{node['ganglia']['ubuntu_version']}.deb"
-  end
-
 when "redhat", "centos", "fedora"
   user "ganglia"
   case node['ganglia']['install_method']

--- a/recipes/gmetad.rb
+++ b/recipes/gmetad.rb
@@ -2,12 +2,16 @@ case node['platform']
 when "debian"
   package "gmetad"
 when "ubuntu"
-  package "librrd-dev"
-  remote_file "/usr/src/#{node['ganglia']['gmetad_install']}_#{node['ganglia']['ubuntu_version']}.deb" do
-    source "#{node['ganglia']['download_url']}/#{node['ganglia']['gmetad_install']}_#{node['ganglia']['ubuntu_version']}.deb"
+  case node['platform_version']
+  when '12.04'
+    package 'librrd-dev'
+    remote_file "/usr/src/#{node['ganglia']['gmetad_install']}_#{node['ganglia']['ubuntu_version']}.deb" do
+      source "#{node['ganglia']['download_url']}/#{node['ganglia']['gmetad_install']}_#{node['ganglia']['ubuntu_version']}.deb"
+    end
+    dpkg_package "/usr/src/#{node['ganglia']['gmetad_install']}_#{node['ganglia']['ubuntu_version']}.deb"
+  else
+    package 'gmetad'
   end
-  dpkg_package "/usr/src/#{node['ganglia']['gmetad_install']}_#{node['ganglia']['ubuntu_version']}.deb"
- 
 when "redhat", "centos", "fedora"
   case node['ganglia']['install_method']
   when 'package'

--- a/recipes/gmetad.rb
+++ b/recipes/gmetad.rb
@@ -1,6 +1,13 @@
 case node['platform']
-when "ubuntu", "debian"
+when "debian"
   package "gmetad"
+when "ubuntu"
+  package "librrd-dev"
+  remote_file "/usr/src/#{node['ganglia']['gmetad_install']}_#{node['ganglia']['ubuntu_version']}.deb" do
+    source "#{node['ganglia']['download_url']}/#{node['ganglia']['gmetad_install']}_#{node['ganglia']['ubuntu_version']}.deb"
+  end
+  dpkg_package "/usr/src/#{node['ganglia']['gmetad_install']}_#{node['ganglia']['ubuntu_version']}.deb"
+ 
 when "redhat", "centos", "fedora"
   case node['ganglia']['install_method']
   when 'package'


### PR DESCRIPTION
For Ubuntu 12.04, the default install version for Ganglia-monitor and Gmetad is 3.1.7, which does not support send metrics to graphite.
So for Ubuntu 12.04, the recipe will download Debian packages and install them, the version is 3.3.8,which support send metrics to graphite.