### PR TITLE
check for collectors without network addresses

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -81,7 +81,7 @@ if node['ganglia']['unicast']
   elsif gmond_collectors.empty?
     gmond_collectors = search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node['ipaddress']}
   end rescue NoMethodError
-  if gmond_collectors.empty?
+  if not gmond_collectors.any?
      gmond_collectors = ["127.0.0.1"]
   end
 


### PR DESCRIPTION
When using this cookbook with a ganglia server_role, the first node
launched will find itself as a collector after registering with
chef-server, but before returning network attributes. This means that
gmond_collectors will contain [nil] from the map, and .empty? will
return true. Using .any? instead checks for this failure case, falling
back to 127.0.0.1 until the next chef-client run, where it will be
updated with the local address.