### PR TITLE
prevent nil gmond_collectors addresses

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -79,7 +79,7 @@ if node['ganglia']['unicast']
   if node['ganglia']['server_host']
     gmond_collectors = [node['ganglia']['server_host']]
   elsif gmond_collectors.empty?
-    gmond_collectors = search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node['ipaddress']}
+    gmond_collectors = search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node['ipaddress']}.compact
   end rescue NoMethodError
   if not gmond_collectors.any?
      gmond_collectors = ["127.0.0.1"]


### PR DESCRIPTION
When using this cookbook with a ganglia server_role, each node
launched will find itself as a collector after registering with
chef-server, but before returning network attributes. This means that
gmond_collectors will contain [nil] from the map, which confuses the
gmond.conf template with an empty value, preventing the service from
starting. .compact removes the nil values, and on the second chef-client
run, all correct addresses will be included.