### PR TITLE
fix FC003 portability errors, allowing usage with vagrant/chef-solo

### DIFF
--- a/recipes/aggregator.rb
+++ b/recipes/aggregator.rb
@@ -10,9 +10,15 @@
 # Go through all nodes that have aggregated metrics and are in our environment.
 # For each node type that we haven't seen before (as judged by hostname minus digits)
 # add whatever metrics you find there into the cluster's list of metrics
+#
+if Chef::Config[:solo]
+  raise 'This recipe requires search. Chef Solo does not support search.'
+end
+
 metrics = {
 }
 seen = {}
+nodes = search(:node, "ganglia_aggregated_metrics:* AND chef_environment:#{node.chef_environment}")
 search(:node, "ganglia_aggregated_metrics:* AND chef_environment:#{node.chef_environment}").each do |server|
   cluster = (server.ganglia.host_cluster.keys.select {|x| server.ganglia.host_cluster[x] == 1})[0]
   aggregated_metrics = server.ganglia.aggregated_metrics

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -79,7 +79,13 @@ if node['ganglia']['unicast']
   if node['ganglia']['server_host']
     gmond_collectors = [node['ganglia']['server_host']]
   elsif gmond_collectors.empty?
-    gmond_collectors = search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node['ipaddress']}
+    if Chef::Config[:solo]
+      Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
+      Chef::Log.warn('Defaulting to localhost collector.')
+      gmond_collectors = ["127.0.0.1"]
+    else
+      gmond_collectors = search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node['ipaddress']}
+    end
   end rescue NoMethodError
   if gmond_collectors.empty?
      gmond_collectors = ["127.0.0.1"]

--- a/recipes/graphite.rb
+++ b/recipes/graphite.rb
@@ -1,4 +1,8 @@
-graphite_host = search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node['ipaddress']}
+if Chef::Config[:solo]
+  graphite_host = "localhost"
+else
+  graphite_host = search(:node, "role:#{node['ganglia']['server_role']} AND chef_environment:#{node.chef_environment}").map {|node| node['ipaddress']}
+end
 if graphite_host.empty?
   graphite_host = "localhost"
 end

--- a/recipes/iptables.rb
+++ b/recipes/iptables.rb
@@ -3,7 +3,7 @@ include_recipe "iptables"
 iptables_rule "http"
 iptables_rule "https"
 
-workers = search(:node, "*:*")  || []
+workers = Chef::Config[:solo] ? [] : search(:node, "*:*")
 subnets = []
 
 workers.each do |w|


### PR DESCRIPTION
Check whether you are running with chef server before using server-specific features.