### PR TITLE
changing node.platform_version to node['platform_version'] for chef 13

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email "ganglia-developers@lists.sourceforge.net"
 license          "Apache 2.0"
 description      "Installs/Configures ganglia"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.6"
+version          "0.2.7"
 
 %w{ debian ubuntu redhat centos fedora }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -138,7 +138,7 @@ service "ganglia-monitor" do
     service_name 'gmond'
   else
     pattern 'gmond'
-    provider Chef::Provider::Service::Upstart if (platform?('ubuntu') && node.platform_version.include?('14'))
+    provider Chef::Provider::Service::Upstart if (platform?('ubuntu') && node['platform_version'].include?('14'))
   end
   supports :restart => true
   action [ :enable, :start ]


### PR DESCRIPTION
If the chef-client  version 13 is used then it fails wit with the following message

```
==> default: NoMethodError
==> default: -------------
==> default: undefined method `platform_version' for #<Chef::Node::Attribute:0x0000000002d59d30>
==> default: 
==> default: Cookbook Trace:
==> default: ---------------
==> default:   /var/chef/cache/cookbooks/ganglia/recipes/default.rb:141:in `block in from_file'
==> default:   /var/chef/cache/cookbooks/ganglia/recipes/default.rb:136:in `from_file'
==> default: 
==> default: Relevant File Content:
==> default: ----------------------
==> default: /var/chef/cache/cookbooks/ganglia/recipes/default.rb:
==> default: 
==> default: 134:  end
==> default: 135:  
==> default: 136:  service "ganglia-monitor" do
==> default: 137:    if platform_family?('rhel')
==> default: 138:      service_name 'gmond'
==> default: 139:    else
==> default: 140:      pattern 'gmond'
==> default: 141>>     provider Chef::Provider::Service::Upstart if (platform?('ubuntu') && node.platform_version.include?('14'))
==> default: 142:    end
==> default: 143:    supports :restart => true
==> default: 144:    action [ :enable, :start ]
==> default: 145:  end
==> default: 146:  
==> default: 
==> default: System Info:
==> default: ------------
==> default: chef_version=13.4.24
==> default: platform=ubuntu
==> default: platform_version=14.04
==> default: ruby=ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux]
==> default: program_name=chef-client worker: ppid=1727;start=17:40:18;
==> default: executable=/opt/chef/bin/chef-client

```